### PR TITLE
Added attr_group, attr_prefix, and value_key options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ console.log(json);
 ```javascript
 var x2j = require('rapidx2j');
 var options = {
+  attr_group: false,
+  attr_prefix: '@',
   empty_tag_value: null,
   parse_boolean_values: true,
   parse_int_numbers: true,
   parse_float_numbers: true,
   preserve_case: false,
-  skip_parse_when_begins_with: ''  
+  skip_parse_when_begins_with: '',
+  value_key: 'keyValue'
 };
 var json = x2j.parse(xml_string, options);
 console.log(json);

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Note that by default, rapidx2j will use 'true' as a value for empty XML tags; wi
 
 * Damir Nedžibović ([@Damirn](https://github.com/damirn))
 * Sander Steenhuis ([@Redsandro](https://twitter.com/Redsandro))
+* Chris Bricker ([@NFNChris](https://github.com/NFNChris))
 
 ## License & copyright
 

--- a/test/attr_group.js
+++ b/test/attr_group.js
@@ -1,0 +1,10 @@
+var assert = require('assert'),
+    r = require('../build/Release/rapidx2j'),
+    x = '<x><a attr1="a" attr2="b">val</a></x>';
+
+var oGroupAttr = r.parse(x, { attr_group: true });
+var oNoGroupAttr = r.parse(x, { attr_group: false });
+
+assert('attr1' in oGroupAttr.a['@'] && 'attr2' in oGroupAttr.a['@']);
+assert('@attr1' in oNoGroupAttr.a && '@attr2' in oNoGroupAttr.a);
+

--- a/test/attr_prefix.js
+++ b/test/attr_prefix.js
@@ -1,0 +1,10 @@
+var assert = require('assert'),
+    r = require('../build/Release/rapidx2j'),
+    x = '<x><a attr1="a" attr2="b">val</a></x>';
+
+var oAttrPrefix = r.parse(x, { attr_prefix: '_' });
+var oAttrNoPrefix = r.parse(x);
+
+assert('_attr1' in oAttrPrefix.a && '_attr2' in oAttrPrefix.a);
+assert('@attr1' in oAttrNoPrefix.a && '@attr2' in oAttrNoPrefix.a);
+

--- a/test/value_key.js
+++ b/test/value_key.js
@@ -1,0 +1,10 @@
+var assert = require('assert'),
+    r = require('../build/Release/rapidx2j'),
+    x = '<x><a attr1="a" attr2="b">val</a></x>';
+
+var oValueKey = r.parse(x, { value_key: '&' });
+var oNoValueKey = r.parse(x);
+
+assert('&' in oValueKey.a);
+assert('keyValue' in oNoValueKey.a);
+


### PR DESCRIPTION
Adds the ability to do the following:

1) Modify the attribute prefix via the attr_prefix option (default '@')
2) Optionally group attributes under the attribute prefix via the attr_group option (default false)
3) Modify the node value key via the value_key option (default 'keyValue')

This hopefully gets us closer to being a drop-in replacement for some other, slower, solutions