### PR TITLE
Remove global options variables

### DIFF
--- a/src/parser.cc
+++ b/src/parser.cc
@@ -3,18 +3,31 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <memory>
 #include <string>
 #include <errno.h>
 
-static v8::Local<v8::Value> gEmptyTagValue; // default value for empty tags
-static bool gGroupAttributes;
-static bool gParseBoolean;
-static bool gParseDouble;
-static bool gParseInteger;
-static bool gPreserveCase;
-static std::string gAttributePrefix;
-static std::string gBeginsWith;
-static std::string gValueKey;
+struct Options {
+  v8::Local<v8::Value> emptyTagValue;
+
+  bool groupAttributes;
+  bool parseInteger;
+  bool parseBoolean;
+  bool parseDouble;
+  bool preserveCase;
+
+  std::string attributePrefix;
+  std::string beginsWith;
+  std::string valueKey;
+
+  void SaveToPersistent(Nan::AsyncWorker *worker) {
+    worker->SaveToPersistent("emptyTagValue", emptyTagValue);
+  }
+
+  void LoadFromPersistent(Nan::AsyncWorker *worker) {
+    emptyTagValue = worker->GetFromPersistent("emptyTagValue");
+  }
+};
 
 static std::string trim(const std::string &s)
 {
@@ -30,15 +43,15 @@ static void toLower(std::string &s)
   std::transform(s.begin(), s.end(), s.begin(), ::tolower);
 }
 
-static v8::Local<v8::Value> parseText(const std::string &text)
+static v8::Local<v8::Value> parseText(const Options &options, const std::string &text)
 {
   if (text.find_first_not_of(" \t\n\r") == std::string::npos) // empty string
     return Nan::Null();
 
   std::string tmp = text;
-  if (!gPreserveCase)
+  if (!options.preserveCase)
     toLower(tmp);
-  if (gParseBoolean)
+  if (options.parseBoolean)
   {
     if (tmp == "true")
       return Nan::New<v8::Boolean>(true);
@@ -46,17 +59,17 @@ static v8::Local<v8::Value> parseText(const std::string &text)
       return Nan::New<v8::Boolean>(false);
   }
 
-  if (gBeginsWith.length() > 0 && text.find_first_of(gBeginsWith) == 0)
+  if (options.beginsWith.length() > 0 && text.find_first_of(options.beginsWith) == 0)
     return Nan::New<v8::String>(text).ToLocalChecked();
 
   char *c = const_cast<char *>(text.c_str());
-  if (gParseDouble)
+  if (options.parseDouble)
   {
     double d = ::strtod(text.c_str(), &c);
     if (*c == '\0')
       return Nan::New<v8::Number>(d);
   }
-  else if (gParseInteger)
+  else if (options.parseInteger)
   {
     long l = ::strtol(text.c_str(), &c, 10);
     if (!(text.c_str() == c || *c != '\0' || ((l == LONG_MIN || l == LONG_MAX) && errno == ERANGE)))
@@ -66,9 +79,9 @@ static v8::Local<v8::Value> parseText(const std::string &text)
   return Nan::New<v8::String>(text).ToLocalChecked();
 }
 
-static v8::Local<v8::Value> walk(const rapidxml::xml_node<> *node)
+static v8::Local<v8::Value> walk(const Options &options, const rapidxml::xml_node<> *node)
 {
-  v8::Local<v8::Value> ret = gEmptyTagValue;
+  v8::Local<v8::Value> ret = options.emptyTagValue;
   int len = 0;
   std::string collected = "";
 
@@ -77,26 +90,26 @@ static v8::Local<v8::Value> walk(const rapidxml::xml_node<> *node)
   if (node->first_attribute())
   {
     v8::Local<v8::Value> attr = ret = Nan::New<v8::Object>();
-    
-    if (gGroupAttributes) {
+
+    if (options.groupAttributes) {
       attr = Nan::New<v8::Object>();
-      v8::Local<v8::Object>::Cast(ret)->Set(Nan::New<v8::String>(gAttributePrefix).ToLocalChecked(), attr);
+      v8::Local<v8::Object>::Cast(ret)->Set(Nan::New<v8::String>(options.attributePrefix).ToLocalChecked(), attr);
     }
-    
+
     for (const rapidxml::xml_attribute<> *a = node->first_attribute(); a; a = a->next_attribute())
     {
       std::string tmp;
       ++len;
 
-      if (gGroupAttributes) {
+      if (options.groupAttributes) {
         tmp = std::string(a->name());
       } else {
-        tmp = gAttributePrefix + std::string(a->name());
+        tmp = options.attributePrefix + std::string(a->name());
       }
-      
-      if (!gPreserveCase)
+
+      if (!options.preserveCase)
         toLower(tmp);
-      v8::Local<v8::Object>::Cast(attr)->Set(Nan::New<v8::String>(tmp).ToLocalChecked(), parseText(trim(std::string(a->value()))));
+      v8::Local<v8::Object>::Cast(attr)->Set(Nan::New<v8::String>(tmp).ToLocalChecked(), parseText(options, trim(std::string(a->value()))));
     }
   }
 
@@ -112,8 +125,9 @@ static v8::Local<v8::Value> walk(const rapidxml::xml_node<> *node)
       if (len == 0)
         ret = Nan::New<v8::Object>();
       std::string prop = n->name();
-      if (!gPreserveCase) toLower(prop);
-      v8::Local<v8::Value> obj = walk(n);
+      if (!options.preserveCase)
+        toLower(prop);
+      v8::Local<v8::Value> obj = walk(options, n);
       v8::Local<v8::Object> myret = v8::Local<v8::Object>::Cast(ret);
 
       v8::Local<v8::String> key = Nan::New<v8::String>(prop).ToLocalChecked();
@@ -140,15 +154,15 @@ static v8::Local<v8::Value> walk(const rapidxml::xml_node<> *node)
   if (collected.length() > 0)
   {
     if (len > 0)
-      v8::Local<v8::Object>::Cast(ret)->Set(Nan::New<v8::String>(gValueKey).ToLocalChecked(), parseText(collected));
+      v8::Local<v8::Object>::Cast(ret)->Set(Nan::New<v8::String>(options.valueKey).ToLocalChecked(), parseText(options, collected));
     else
-      ret = parseText(collected);
+      ret = parseText(options, collected);
   }
 
   return ret;
 }
 
-static bool parseArgs(const Nan::FunctionCallbackInfo<v8::Value> &args)
+static bool parseArgs(const Nan::FunctionCallbackInfo<v8::Value> &args, Options &options)
 {
   if (args.Length() < 1)
   {
@@ -172,62 +186,64 @@ static bool parseArgs(const Nan::FunctionCallbackInfo<v8::Value> &args)
       v8::Local<v8::Object> tmp = v8::Local<v8::Object>::Cast(args[1]);
       if (Nan::HasOwnProperty(tmp, Nan::New<v8::String>("attr_prefix").ToLocalChecked()).FromMaybe(false)) {
         v8::String::Utf8Value gAttributePrefixObj(tmp->Get(Nan::New<v8::String>("attr_prefix").ToLocalChecked())->ToString());
-        gAttributePrefix = *gAttributePrefixObj;
+        options.attributePrefix = *gAttributePrefixObj;
       }
       else
-        gAttributePrefix = "@";
+        options.attributePrefix = "@";
       if (!Nan::HasOwnProperty(tmp, Nan::New<v8::String>("empty_tag_value").ToLocalChecked()).FromMaybe(false))
-        gEmptyTagValue = Nan::New<v8::Boolean>(true);
+        options.emptyTagValue = Nan::New<v8::Boolean>(true);
       else
-        gEmptyTagValue = tmp->Get(Nan::New<v8::String>("empty_tag_value").ToLocalChecked());
+        options.emptyTagValue = tmp->Get(Nan::New<v8::String>("empty_tag_value").ToLocalChecked());
       if (Nan::HasOwnProperty(tmp, Nan::New<v8::String>("value_key").ToLocalChecked()).FromMaybe(false)) {
         v8::String::Utf8Value gValueKeyObj(tmp->Get(Nan::New<v8::String>("value_key").ToLocalChecked())->ToString());
-        gValueKey = *gValueKeyObj;
+        options.valueKey = *gValueKeyObj;
       }
       else
-        gValueKey = "keyValue";
+        options.valueKey = "keyValue";
       if (Nan::HasOwnProperty(tmp, Nan::New<v8::String>("attr_group").ToLocalChecked()).FromMaybe(false))
-        gGroupAttributes = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("attr_group").ToLocalChecked()).ToLocalChecked()).FromJust();
+        options.groupAttributes = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("attr_group").ToLocalChecked()).ToLocalChecked()).FromJust();
       else
-        gGroupAttributes = false;        
+        options.groupAttributes = false;
       if (Nan::HasOwnProperty(tmp, Nan::New<v8::String>("parse_boolean_values").ToLocalChecked()).FromMaybe(false))
-        gParseBoolean = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("parse_boolean_values").ToLocalChecked()).ToLocalChecked()).FromJust();
+        options.parseBoolean = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("parse_boolean_values").ToLocalChecked()).ToLocalChecked()).FromJust();
       else
-        gParseBoolean = true;        
+        options.parseBoolean = true;
       if (Nan::HasOwnProperty(tmp, Nan::New<v8::String>("parse_float_numbers").ToLocalChecked()).FromMaybe(false))
-        gParseDouble = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("parse_float_numbers").ToLocalChecked()).ToLocalChecked()).FromJust();
+        options.parseDouble = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("parse_float_numbers").ToLocalChecked()).ToLocalChecked()).FromJust();
       else
-        gParseDouble = true;
+        options.parseDouble = true;
       if (Nan::HasOwnProperty(tmp, Nan::New<v8::String>("parse_int_numbers").ToLocalChecked()).FromMaybe(false))
-        gParseInteger = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("parse_int_numbers").ToLocalChecked()).ToLocalChecked()).FromJust();
+        options.parseInteger = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("parse_int_numbers").ToLocalChecked()).ToLocalChecked()).FromJust();
       else
-        gParseInteger = true;
+        options.parseInteger = true;
       if (Nan::HasOwnProperty(tmp, Nan::New<v8::String>("preserve_case").ToLocalChecked()).FromMaybe(false))
-        gPreserveCase = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("preserve_case").ToLocalChecked()).ToLocalChecked()).FromJust();
+        options.preserveCase = Nan::To<bool>(Nan::Get(tmp, Nan::New<v8::String>("preserve_case").ToLocalChecked()).ToLocalChecked()).FromJust();
       else
-        gPreserveCase = false;        
+        options.preserveCase = false;
       v8::String::Utf8Value s(tmp->Get(Nan::New<v8::String>("skip_parse_when_begins_with").ToLocalChecked())->ToString());
-      gBeginsWith = *s;
+      options.beginsWith = *s;
     }
   }
   else
   {
-    gEmptyTagValue = Nan::New<v8::Boolean>(true);
-    gGroupAttributes = false;    
-    gParseBoolean = true;
-    gParseDouble = true;
-    gParseInteger = true;
-    gPreserveCase = false;
-    gAttributePrefix = "@";
-    gBeginsWith = "";
-    gValueKey = "keyValue";
+    options.emptyTagValue = Nan::New<v8::Boolean>(true);
+    options.groupAttributes = false;
+    options.parseBoolean = true;
+    options.parseDouble = true;
+    options.parseInteger = true;
+    options.preserveCase = false;
+    options.attributePrefix = "@";
+    options.beginsWith = "";
+    options.valueKey = "keyValue";
   }
   return true;
 }
 
 NAN_METHOD(parse)
 {
-  if (!parseArgs(info))
+  Options options;
+
+  if (!parseArgs(info, options))
   {
     info.GetReturnValue().SetUndefined();
     return;
@@ -249,7 +265,7 @@ NAN_METHOD(parse)
   {
     if (!doc.first_node()->first_attribute() && !doc.first_node()->first_node())
       return info.GetReturnValue().Set(Nan::New<v8::Object>());
-    v8::Local<v8::Value> obj = walk(doc.first_node());
+    v8::Local<v8::Value> obj = walk(options, doc.first_node());
     info.GetReturnValue().Set(obj);
     return;
   }
@@ -260,10 +276,13 @@ NAN_METHOD(parse)
 class AsyncParser : public Nan::AsyncWorker
 {
 public:
-  AsyncParser(Nan::Callback *callback, Nan::Utf8String *xml)
+  AsyncParser(Nan::Callback *callback, Nan::Utf8String *xml, std::unique_ptr<Options> &&options)
   : Nan::AsyncWorker(callback)
   , m_xml(xml)
-  {}
+  , m_options(std::move(options))
+  {
+    m_options->SaveToPersistent(this);
+  }
 
   ~AsyncParser()
   {
@@ -284,18 +303,19 @@ public:
 
   virtual void HandleOKCallback()
   {
-    Nan::HandleScope scope;
+    m_options->LoadFromPersistent(this);
 
+    Nan::HandleScope scope;
     v8::Local<v8::Value> val = Nan::Undefined();
     if (m_doc.first_node())
     {
       if (!m_doc.first_node()->first_attribute() && !m_doc.first_node()->first_node())
           val = Nan::New<v8::Object>();
       else
-          val = walk(m_doc.first_node());
+          val = walk(*m_options, m_doc.first_node());
     }
 
-    v8::Local<v8::Value> argv[] = 
+    v8::Local<v8::Value> argv[] =
     {
       Nan::Null(),
       val
@@ -306,12 +326,14 @@ public:
 private:
   Nan::Utf8String *m_xml;
   rapidxml::xml_document<char> m_doc;
-  v8::Local<v8::Value> m_result;
+  std::unique_ptr<Options> m_options;
 };
 
 NAN_METHOD(parseAsync)
 {
-  if (!parseArgs(info))
+  std::unique_ptr<Options> options(new Options());
+
+  if (!parseArgs(info, *options))
   {
     info.GetReturnValue().SetUndefined();
     return;
@@ -331,7 +353,7 @@ NAN_METHOD(parseAsync)
   }
   Nan::Utf8String *xml = new Nan::Utf8String(info[0]);
   Nan::Callback *cb = new Nan::Callback(info[2].As<v8::Function>());
-  Nan::AsyncQueueWorker(new AsyncParser(cb, xml));
+  Nan::AsyncQueueWorker(new AsyncParser(cb, xml, std::move(options)));
 
   info.GetReturnValue().SetUndefined();
 }

--- a/test/async.js
+++ b/test/async.js
@@ -1,0 +1,17 @@
+var assert = require('assert'),
+    r = require('../build/Release/rapidx2j'),
+	x = '<a b="1"></a>';
+
+r.parseAsync(x, {
+	attr_prefix: 'attr1_'
+}, function (err, o) {
+	assert.equal(o.attr1_b, 1);
+	assert.equal(o.attr2_b, undefined);
+});
+
+r.parseAsync(x, {
+	attr_prefix: 'attr2_'
+}, function (err, o) {
+	assert.equal(o.attr1_b, undefined);
+	assert.equal(o.attr2_b, 1);
+});


### PR DESCRIPTION
The options' values will get mixed up when the library is being used asynchronously. Sometimes it can even cause the Node process to crash. I've added a test to demonstrate the problem.